### PR TITLE
Update link iteration key

### DIFF
--- a/src/components/links.svelte
+++ b/src/components/links.svelte
@@ -28,7 +28,7 @@
 </script>
 
 <ol class="flow links">
-	{#each links as link, index (link.href.concat(" ", link.addedOn ?? "")}
+	{#each links as link, index (link.href.concat(" ", link.addedOn ?? ""))}
 		<li class="link">
 			<a href={link.href} rel="nofollow" class="link-title">
 				{link.title}

--- a/src/components/links.svelte
+++ b/src/components/links.svelte
@@ -28,11 +28,7 @@
 </script>
 
 <ol class="flow links">
-	<!--
-    TODO: when adding a link with the same href as one already present, an edge case is hit
-    and rendering of the list might break
-  -->
-	{#each links as link, index (link.href)}
+	{#each links as link, index (link.href.concat(" ", link.addedOn ?? "")}
 		<li class="link">
 			<a href={link.href} rel="nofollow" class="link-title">
 				{link.title}


### PR DESCRIPTION
This adresses the issue where two Links with the same href break link list rendering.

Even if two Links get added in the same second, they (hopefully) have the same href.